### PR TITLE
Include sgui

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ dependencies {
 	modImplementation include("eu.pb4:placeholder-api:2.4.1+1.21")
 
 	// Server GUI API
-	modImplementation "eu.pb4:sgui:1.6.0+1.21"
+	modImplementation include("eu.pb4:sgui:1.6.0+1.21")
 
 	// SnakeYAML dependency
 	implementation "org.yaml:snakeyaml:2.1"


### PR DESCRIPTION
SGUI is not being included, which can cause crashes if no other mods also include it. I didn't see a mention of this anywhere